### PR TITLE
Updates table formatting to render correctly

### DIFF
--- a/appendixa.md
+++ b/appendixa.md
@@ -2,9 +2,9 @@
 
 (\*) denotes a required field
 
-| General |
-| --- |
-| General Information |
+| General | |
+| --- | --- |
+| General Information | |
 | Unit Name\* | Generator Name |
 | Facility Name\* | Name of the facility (some facilities may have multiple units) |
 | WI RRC Unit ID | Wisconsin PSC assigned RRC Unit ID |
@@ -26,10 +26,7 @@
 | Additional Owner(s) | If this is not a single owner, list the additional owners |
 | Owner Contact Information |
 | Company Name\* | Owner that holds legal title to the Generator |
-| Address\* | Contact information of owner referenced above
-
-
- |
+| Address\* | Contact information of owner referenced above |
 | City\* |
 | State/Province\* |
 | Zip/Postal Code\* |


### PR DESCRIPTION
There were some parsing issues I ran into when trying to get this to render in the mrets repo. There was another issue I saw where this rendered as two tables instead of one... I don't think that was intentional.

Before:
<img width="1234" alt="Screen Shot 2020-06-09 at 3 49 00 PM" src="https://user-images.githubusercontent.com/1489561/84198955-f8c26980-aa69-11ea-83bf-7a7ef78c94b6.png">

After: 
<img width="1008" alt="Screen Shot 2020-06-09 at 3 49 30 PM" src="https://user-images.githubusercontent.com/1489561/84198975-02e46800-aa6a-11ea-9b15-81203abfbeeb.png">

