### PR TITLE
Update links to open in a new tab

### DIFF
--- a/api-docs/scenarios/index.md
+++ b/api-docs/scenarios/index.md
@@ -1,8 +1,8 @@
 # Examples
 
-* [Get REC Inventory](https://github.com/mrets/Operating-Procedures/blob/master/api-docs/scenarios/get-recs.md)
-* [Get Generation History](https://github.com/mrets/Operating-Procedures/blob/master/api-docs/scenarios/get-generation-history.md)
-* [Get Transaction History](https://github.com/mrets/Operating-Procedures/blob/master/api-docs/scenarios/get-transaction-history.md)
-* [Register a Generator](https://github.com/mrets/Operating-Procedures/blob/master/api-docs/scenarios/register-a-generator.md)
-* [Retire Certificates](https://github.com/mrets/Operating-Procedures/blob/master/api-docs/scenarios/retire-certificates.md)
-* [Transfer Certificates](https://github.com/mrets/Operating-Procedures/blob/master/api-docs/scenarios/transfer-certificates.md)
+* <a href="https://github.com/mrets/Operating-Procedures/blob/master/api-docs/scenarios/get-recs.md" target="_blank">Get REC Inventory</a>
+* <a href="https://github.com/mrets/Operating-Procedures/blob/master/api-docs/scenarios/get-generation-history.md" target="_blank">Get Generation History</a>
+* <a href="https://github.com/mrets/Operating-Procedures/blob/master/api-docs/scenarios/get-transaction-history.md" target="_blank">Get Transaction History</a>
+* <a href="https://github.com/mrets/Operating-Procedures/blob/master/api-docs/scenarios/register-a-generator.md" target="_blank">Register a Generator</a>
+* <a href="https://github.com/mrets/Operating-Procedures/blob/master/api-docs/scenarios/retire-certificates.md" target="_blank">Retire Certificates</a>
+* <a href="https://github.com/mrets/Operating-Procedures/blob/master/api-docs/scenarios/transfer-certificates.md" target="_blank">Transfer Certificates</a>


### PR DESCRIPTION
Since our markdown parser doesn't allow additional attributes, the links were updated to HTML links